### PR TITLE
fix: handle whitespace around array brackets

### DIFF
--- a/lib/json5/decode/backend/combine/array.ex
+++ b/lib/json5/decode/backend/combine/array.ex
@@ -7,29 +7,20 @@ defmodule Json5.Decode.Backend.Combine.Array do
   import Json5.Decode.Backend.Combine.Helper
 
   def array do
-    either(
-      pipe(
-        [
-          ignore_whitespace(),
-          char("["),
-          ignore_whitespace(),
-          char("]"),
-          ignore_whitespace()
-        ],
-        fn _ -> [] end
+    between(
+      ignore(sequence([ignore_whitespace(), char("[")])),
+      either(
+        pipe(
+          [
+            ignore_whitespace(),
+            array_items(),
+            ignore_whitespace()
+          ],
+          fn [expr] -> expr end
+        ),
+        map(ignore_whitespace(), fn _ -> [] end)
       ),
-      pipe(
-        [
-          ignore_whitespace(),
-          ignore(char("[")),
-          ignore_whitespace(),
-          array_items(),
-          ignore_whitespace(),
-          ignore(char("]")),
-          ignore_whitespace()
-        ],
-        fn [expr] -> expr end
-      )
+      ignore(sequence([ignore_whitespace(), char("]")]))
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Json5.MixProject do
   def project do
     [
       app: :json5,
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: "~> 1.10",
       description: "Json5 in Elixir",
       start_permanent: Mix.env() == :prod,

--- a/test/json5/decode_test.exs
+++ b/test/json5/decode_test.exs
@@ -33,6 +33,7 @@ defmodule Json5.DecodeTest do
     [:number, decimal("-.123"), "-.123"],
     [:number, decimal("-.123e+7"), "-.123e+7"],
     [:number, decimal("-12.123e+7"), "-12.123e+7"],
+    [:array, [], " []   "],
     [:array, [], "[]"],
     [:array, [nil], "[null]"],
     [:array, [decimal(1)], "[1]"],
@@ -83,6 +84,22 @@ defmodule Json5.DecodeTest do
       """
     ],
     [
+      :comment,
+      Macro.escape(%{
+        "test" => []
+      }),
+      """
+      {
+      "test": [
+        // {
+        // "test2": "",
+        // "test3": "",
+        // },
+        ]
+      }
+      """
+    ],
+    [
       :multi_line_comment,
       [decimal(1), decimal(2)],
       """
@@ -112,6 +129,7 @@ defmodule Json5.DecodeTest do
       """
     ],
     [:object, Macro.escape(%{}), "{}"],
+    [:object, Macro.escape(%{}), "  {} "],
     [:object, Macro.escape(%{}), "{    }"],
     [:object, Macro.escape(%{"a" => Decimal.new(1)}), "{a : 1}"],
     [:object, Macro.escape(%{"test" => Decimal.new(1)}), "{test: 1}"],


### PR DESCRIPTION
fix for: https://github.com/thomas9911/json5/issues/3
